### PR TITLE
Round positions to workaround a bug in heatmap.js.

### DIFF
--- a/src/ReactHeatmap.js
+++ b/src/ReactHeatmap.js
@@ -35,8 +35,8 @@ class ReactHeatmap extends Component {
 			container.height = ReactDOM.findDOMNode(this).offsetHeight;
 			return data.map(function(values, index) {
 				return {
-					x : values.x/100 * container.width,
-					y : values.y/100 * container.height,
+					x : Math.round(values.x/100 * container.width),
+					y : Math.round(values.y/100 * container.height),
 					value: values.value
 				}
 			})


### PR DESCRIPTION
Heatmap.js fails with some non-integer datasets because it doesn't
support subpixel positioning. This is a warkaround around that.

Please refer to https://github.com/pa7/heatmap.js/issues/260
for more information.